### PR TITLE
Rename Grid base class.

### DIFF
--- a/src/WaveBlocksND/AbstractGrid.py
+++ b/src/WaveBlocksND/AbstractGrid.py
@@ -3,14 +3,14 @@
 This file contains the abstract class for representing grids.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2012 R. Bourquin
+@copyright: Copyright (C) 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
-__all__ = ["Grid"]
+__all__ = ["AbstractGrid"]
 
 
-class Grid(object):
+class AbstractGrid(object):
     """This class is an abstract interface to grids in general.
     """
 

--- a/src/WaveBlocksND/DenseGrid.py
+++ b/src/WaveBlocksND/DenseGrid.py
@@ -3,16 +3,16 @@
 This file contains the abstract class for representing dense grids.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2012 R. Bourquin
+@copyright: Copyright (C) 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 
 __all__ = ["DenseGrid"]
 
 
-class DenseGrid(Grid):
+class DenseGrid(AbstractGrid):
     """This class is an abstract interface to dense grids in general.
     """
 

--- a/src/WaveBlocksND/GridWrapper.py
+++ b/src/WaveBlocksND/GridWrapper.py
@@ -4,18 +4,18 @@ This file contains a tiny wrapper to wrap
 numpy ndarrays into Grid instances.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2012, 2013 R. Bourquin
+@copyright: Copyright (C) 2012, 2013, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
 from numpy import atleast_1d, abs
 
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 
 __all__ = ["GridWrapper"]
 
 
-class GridWrapper(Grid):
+class GridWrapper(AbstractGrid):
     r"""This class constructs a thin layer around an ``ndarray`` and wraps
     it as :py:class:`Grid` subclass for API compatibility. The array must
     have a shape of :math:`(D, N)` with :math:`N` the overall number of nodes.

--- a/src/WaveBlocksND/HagedornWavepacketBase.py
+++ b/src/WaveBlocksND/HagedornWavepacketBase.py
@@ -7,12 +7,12 @@ This file contains the basic interface for general wavepackets.
 @license: Modified BSD License
 """
 
-from numpy import vstack, vsplit, cumsum, zeros, array, complexfloating, pi, dot, atleast_2d, einsum
-from scipy import exp, sqrt, conjugate
+from numpy import array, atleast_2d, complexfloating, cumsum, dot, einsum, pi, vsplit, vstack, zeros
+from scipy import conjugate, exp, sqrt
 from scipy.linalg import det, inv, norm
 
 from Wavepacket import Wavepacket
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from GridWrapper import GridWrapper
 from GradientHAWP import GradientHAWP
 
@@ -246,14 +246,14 @@ class HagedornWavepacketBase(Wavepacket):
     # the same way for homogeneous and inhomogeneous Hagedorn wavepackets.
 
 
-    def _grid_wrap(self, grid):
+    def _grid_wrap(self, agrid):
         # TODO: Consider additional input types for "nodes":
         #       list of numpy ndarrays, list of single python scalars
-        if not isinstance(grid, Grid):
-            grid = atleast_2d(grid)
-            grid = grid.reshape(self._dimension, -1)
-            grid = GridWrapper(grid)
-        return grid
+        if not isinstance(agrid, AbstractGrid):
+            agrid = atleast_2d(agrid)
+            agrid = agrid.reshape(self._dimension, -1)
+            agrid = GridWrapper(agrid)
+        return agrid
 
 
     def _evaluate_phi0(self, component, nodes, prefactor=False):

--- a/src/WaveBlocksND/LinearCombinationOfHAWPs.py
+++ b/src/WaveBlocksND/LinearCombinationOfHAWPs.py
@@ -5,7 +5,7 @@ Hagedorn wavepackets in a more efficient and storage friendly way
 than the general linear combination class.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2013 R. Bourquin
+@copyright: Copyright (C) 2013, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
@@ -16,7 +16,7 @@ from scipy.linalg import det, inv
 
 from LinearCombinationOfWavepackets import LinearCombinationOfWavepackets
 from HagedornWavepacket import HagedornWavepacket
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from GridWrapper import GridWrapper
 
 __all__ = ["LinearCombinationOfHAWPs"]
@@ -520,14 +520,14 @@ class LinearCombinationOfHAWPs(LinearCombinationOfWavepackets):
 
     # TODO: Put all evaluation functions into common class
 
-    def _grid_wrap(self, grid):
+    def _grid_wrap(self, agrid):
         # TODO: Consider additional input types for "nodes":
         #       list of numpy ndarrays, list of single python scalars
-        if not isinstance(grid, Grid):
-            grid = atleast_2d(grid)
-            grid = grid.reshape(self._dimension, -1)
-            grid = GridWrapper(grid)
-        return grid
+        if not isinstance(agrid, AbstractGrid):
+            agrid = atleast_2d(agrid)
+            agrid = agrid.reshape(self._dimension, -1)
+            agrid = GridWrapper(agrid)
+        return agrid
 
 
     def _evaluate_phi0(self, nodes, packetindex, prefactor=False):

--- a/src/WaveBlocksND/MatrixPotential1S.py
+++ b/src/WaveBlocksND/MatrixPotential1S.py
@@ -5,7 +5,7 @@ that contain only a single energy level :math:`\lambda_0`. The number
 of space dimensions can be arbitrary, :math:`x \in \mathbb{R}^D`.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2010, 2011, 2012 R. Bourquin
+@copyright: Copyright (C) 2010, 2011, 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
@@ -13,7 +13,7 @@ import sympy
 import numpy
 
 from MatrixPotential import MatrixPotential
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from GridWrapper import GridWrapper
 import GlobalDefaults
 
@@ -77,14 +77,14 @@ class MatrixPotential1S(MatrixPotential):
         self._hessian_n = None
 
 
-    def _grid_wrap(self, grid):
+    def _grid_wrap(self, agrid):
         # TODO: Consider additional input types for "nodes":
         #       list of numpy ndarrays, list of single python scalars
-        if not isinstance(grid, Grid):
-            grid = numpy.atleast_2d(grid)
-            grid = grid.reshape(self._dimension, -1)
-            grid = GridWrapper(grid)
-        return grid
+        if not isinstance(agrid, AbstractGrid):
+            agrid = numpy.atleast_2d(agrid)
+            agrid = agrid.reshape(self._dimension, -1)
+            agrid = GridWrapper(agrid)
+        return agrid
 
 
     def evaluate_at(self, grid, entry=None, as_matrix=False):

--- a/src/WaveBlocksND/MatrixPotential2S.py
+++ b/src/WaveBlocksND/MatrixPotential2S.py
@@ -5,7 +5,7 @@ that contain exactly two energy levels :math:`\lambda_i`. The number
 of space dimensions can be arbitrary, :math:`x \in \mathbb{R}^D`.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2010, 2011, 2012 R. Bourquin
+@copyright: Copyright (C) 2010, 2011, 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
@@ -13,7 +13,7 @@ import sympy
 import numpy
 
 from MatrixPotential import MatrixPotential
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from GridWrapper import GridWrapper
 import GlobalDefaults
 
@@ -90,14 +90,14 @@ class MatrixPotential2S(MatrixPotential):
         self._remainder_eigen_ih_n = None
 
 
-    def _grid_wrap(self, grid):
+    def _grid_wrap(self, agrid):
         # TODO: Consider additional input types for "nodes":
         #       list of numpy ndarrays, list of single python scalars
-        if not isinstance(grid, Grid):
-            grid = numpy.atleast_2d(grid)
-            grid = grid.reshape(self._dimension, -1)
-            grid = GridWrapper(grid)
-        return grid
+        if not isinstance(agrid, AbstractGrid):
+            agrid = numpy.atleast_2d(agrid)
+            agrid = agrid.reshape(self._dimension, -1)
+            agrid = GridWrapper(agrid)
+        return agrid
 
 
     def evaluate_at(self, grid, entry=None, as_matrix=True):

--- a/src/WaveBlocksND/MatrixPotentialMS.py
+++ b/src/WaveBlocksND/MatrixPotentialMS.py
@@ -6,7 +6,7 @@ the code works also with 1 or 2 levels, but it is not used that way.)
 The number of space dimensions can be arbitrary, :math:`x \in \mathbb{R}^D`.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2010, 2011, 2012 R. Bourquin
+@copyright: Copyright (C) 2010, 2011, 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
@@ -15,7 +15,7 @@ import numpy
 from scipy import linalg
 
 from MatrixPotential import MatrixPotential
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from GridWrapper import GridWrapper
 import GlobalDefaults
 
@@ -67,14 +67,14 @@ class MatrixPotentialMS(MatrixPotential):
         self._HV_n = None
 
 
-    def _grid_wrap(self, grid):
+    def _grid_wrap(self, agrid):
         # TODO: Consider additional input types for "nodes":
         #       list of numpy ndarrays, list of single python scalars
-        if not isinstance(grid, Grid):
-            grid = numpy.atleast_2d(grid)
-            grid = grid.reshape(self._dimension, -1)
-            grid = GridWrapper(grid)
-        return grid
+        if not isinstance(agrid, AbstractGrid):
+            agrid = numpy.atleast_2d(agrid)
+            agrid = agrid.reshape(self._dimension, -1)
+            agrid = GridWrapper(agrid)
+        return agrid
 
 
     def evaluate_at(self, grid, entry=None, as_matrix=True):
@@ -342,7 +342,7 @@ class MatrixPotentialMS(MatrixPotential):
 
     def _evaluate_jacobian_of_matrix(self, variable, grid, entry=None):
         # Note: We assume grid is already of supertype Grid
-        #issubclass(type(grid), Grid)
+        #issubclass(type(grid), AbstractGrid)
         n = grid.get_number_nodes(overall=True)
         N = self._number_components
         nodes = grid.get_nodes(split=True)
@@ -357,7 +357,7 @@ class MatrixPotentialMS(MatrixPotential):
 
     def _evaluate_hessian_of_matrix(self, variables, grid, entry=None):
         # Note: We assume grid is already of supertype Grid
-        #issubclass(type(grid), Grid)
+        #issubclass(type(grid), AbstractGrid)
         n = grid.get_number_nodes(overall=True)
         N = self._number_components
         nodes = grid.get_nodes(split=True)

--- a/src/WaveBlocksND/TensorProductGrid.py
+++ b/src/WaveBlocksND/TensorProductGrid.py
@@ -4,12 +4,12 @@ This file contains a class for representing
 dense regular tensor product grids.
 
 @author: R. Bourquin
-@copyright: Copyright (C) 2012 R. Bourquin
+@copyright: Copyright (C) 2012, 2014 R. Bourquin
 @license: Modified BSD License
 """
 
 import operator
-from numpy import mgrid, ogrid, atleast_1d, array, diff, squeeze, hstack, floating, complexfloating
+from numpy import array, atleast_1d, complexfloating, diff, floating, hstack, mgrid, ogrid, squeeze
 
 from DenseGrid import DenseGrid
 

--- a/src/WaveBlocksND/__init__.py
+++ b/src/WaveBlocksND/__init__.py
@@ -11,7 +11,7 @@ __version__ = 0.2
 from ComplexMath import ContinuousSqrt
 
 # Grids
-from Grid import Grid
+from AbstractGrid import AbstractGrid
 from DenseGrid import DenseGrid
 from TensorProductGrid import TensorProductGrid
 from GridWrapper import GridWrapper


### PR DESCRIPTION
Reason: There are too many things named 'Grid' and this should
reduce namespace collsisions. The isinstance bug is still not
resolved.
